### PR TITLE
fix: fixed text error in copyright section of footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
         </section>
 
         <div class="copyright">
-            <p>&copy; 2022 Compassionate Hearts of Kansas City</p>
+            <p>&copy; 2022 Buffalo Converter</p>
         </div>
     </footer>
 


### PR DESCRIPTION
There was a copyright error to another name unrelated to the project. I replaced the copyright text with the correct one.